### PR TITLE
fix: Fix broken links to the Creative Commons website

### DIFF
--- a/content/about/index.md
+++ b/content/about/index.md
@@ -35,7 +35,7 @@ AIやGISの分野はとても奥深い一方、覚えることがたくさんあ
 
 ## ライセンス
 
-* **当Webサイトのコンテンツ**は [CC BY-SA 4.0 国際](https://creativecommons.jp/sciencecommons/aboutcc0/) ライセンスで公開します。  
+* **当Webサイトのコンテンツ**は [CC BY-SA 4.0 国際](https://creativecommons.org/licenses/by-sa/4.0/deed.ja) ライセンスで公開します。  
 ただし、**ページ内で特に記載がある場合は、そのライセンスが優先します**。
 明示的な記載の有無にかかわらず、第三者が権利を有するコンテンツについては、利用者の責任で利用許諾を得てください。
 

--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -14,7 +14,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
   <div class="flex justify-between w-100 mw9">
     <div class="f5 fw4 pv2 ph3 white-70">
       &copy; {{ with .Site.Copyright | default .Site.Title }} {{ . | safeHTML }} {{ end }} {{ now.Format "2006"}}.
-      <a class="hover-white white-70" href="">CC BY-SA 4.0</a> unless otherwise noted.
+      <a class="hover-white white-70" href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> unless otherwise noted.
       <a class="hover-white white-70" href="{{ .Site.Params.license_page_url
           }}">More about license...</a>
     </div>

--- a/public/404.html
+++ b/public/404.html
@@ -149,7 +149,7 @@
   <div class="flex justify-between w-100 mw9">
     <div class="f5 fw4 pv2 ph3 white-70">
       &copy;  Yuki Sasaki  2023.
-      <a class="hover-white white-70" href="">CC BY-SA 4.0</a> unless otherwise noted.
+      <a class="hover-white white-70" href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> unless otherwise noted.
       <a class="hover-white white-70" href="/about">More about license...</a>
     </div>
     <div>

--- a/public/about/index.html
+++ b/public/about/index.html
@@ -218,7 +218,7 @@ Web ページのソースコードは、GPL 2.0 ライセンスで GitHub に公
 <h2 id="ライセンス">ライセンス</h2>
 <ul>
 <li>
-<p><strong>当Webサイトのコンテンツ</strong>は <a href="https://creativecommons.jp/sciencecommons/aboutcc0/">CC BY-SA 4.0 国際</a> ライセンスで公開します。<br>
+<p><strong>当Webサイトのコンテンツ</strong>は <a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">CC BY-SA 4.0 国際</a> ライセンスで公開します。<br>
 ただし、<strong>ページ内で特に記載がある場合は、そのライセンスが優先します</strong>。
 明示的な記載の有無にかかわらず、第三者が権利を有するコンテンツについては、利用者の責任で利用許諾を得てください。</p>
 </li>
@@ -246,7 +246,7 @@ Web ページのソースコードは、GPL 2.0 ライセンスで GitHub に公
   <div class="flex justify-between w-100 mw9">
     <div class="f5 fw4 pv2 ph3 white-70">
       &copy;  Yuki Sasaki  2023.
-      <a class="hover-white white-70" href="">CC BY-SA 4.0</a> unless otherwise noted.
+      <a class="hover-white white-70" href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> unless otherwise noted.
       <a class="hover-white white-70" href="/about">More about license...</a>
     </div>
     <div>

--- a/public/index.html
+++ b/public/index.html
@@ -388,7 +388,7 @@ Linux は、人工知能・機械学習分野でよく使われるOSです。 �
   <div class="flex justify-between w-100 mw9">
     <div class="f5 fw4 pv2 ph3 white-70">
       &copy;  Yuki Sasaki  2023.
-      <a class="hover-white white-70" href="">CC BY-SA 4.0</a> unless otherwise noted.
+      <a class="hover-white white-70" href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> unless otherwise noted.
       <a class="hover-white white-70" href="/about">More about license...</a>
     </div>
     <div>

--- a/public/posts/index.html
+++ b/public/posts/index.html
@@ -390,7 +390,7 @@
   <div class="flex justify-between w-100 mw9">
     <div class="f5 fw4 pv2 ph3 white-70">
       &copy;  Yuki Sasaki  2023.
-      <a class="hover-white white-70" href="">CC BY-SA 4.0</a> unless otherwise noted.
+      <a class="hover-white white-70" href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> unless otherwise noted.
       <a class="hover-white white-70" href="/about">More about license...</a>
     </div>
     <div>

--- a/public/posts/linux-ml-1/index.html
+++ b/public/posts/linux-ml-1/index.html
@@ -375,7 +375,7 @@ Adobe Photoshop のようなマクロ機能を備えた高性能ソフトを使�
   <div class="flex justify-between w-100 mw9">
     <div class="f5 fw4 pv2 ph3 white-70">
       &copy;  Yuki Sasaki  2023.
-      <a class="hover-white white-70" href="">CC BY-SA 4.0</a> unless otherwise noted.
+      <a class="hover-white white-70" href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> unless otherwise noted.
       <a class="hover-white white-70" href="/about">More about license...</a>
     </div>
     <div>

--- a/public/posts/linux-ml-2/index.html
+++ b/public/posts/linux-ml-2/index.html
@@ -437,7 +437,7 @@ PC 自体のディスク容量によるが、20GB〜25GBほどあれば演習用
   <div class="flex justify-between w-100 mw9">
     <div class="f5 fw4 pv2 ph3 white-70">
       &copy;  Yuki Sasaki  2023.
-      <a class="hover-white white-70" href="">CC BY-SA 4.0</a> unless otherwise noted.
+      <a class="hover-white white-70" href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> unless otherwise noted.
       <a class="hover-white white-70" href="/about">More about license...</a>
     </div>
     <div>

--- a/public/posts/linux-ml-3/index.html
+++ b/public/posts/linux-ml-3/index.html
@@ -465,7 +465,7 @@ Windows や Mac でも、フォルダやファイルの場所を <code>\</code> 
   <div class="flex justify-between w-100 mw9">
     <div class="f5 fw4 pv2 ph3 white-70">
       &copy;  Yuki Sasaki  2023.
-      <a class="hover-white white-70" href="">CC BY-SA 4.0</a> unless otherwise noted.
+      <a class="hover-white white-70" href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> unless otherwise noted.
       <a class="hover-white white-70" href="/about">More about license...</a>
     </div>
     <div>

--- a/public/posts/linux-ml-4/index.html
+++ b/public/posts/linux-ml-4/index.html
@@ -441,7 +441,7 @@ $ ls sonnet.txt cd -: 直前の作業ディレクトリに戻る 直前の作業
   <div class="flex justify-between w-100 mw9">
     <div class="f5 fw4 pv2 ph3 white-70">
       &copy;  Yuki Sasaki  2023.
-      <a class="hover-white white-70" href="">CC BY-SA 4.0</a> unless otherwise noted.
+      <a class="hover-white white-70" href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> unless otherwise noted.
       <a class="hover-white white-70" href="/about">More about license...</a>
     </div>
     <div>

--- a/public/posts/linux-ml-5/index.html
+++ b/public/posts/linux-ml-5/index.html
@@ -536,7 +536,7 @@ $
   <div class="flex justify-between w-100 mw9">
     <div class="f5 fw4 pv2 ph3 white-70">
       &copy;  Yuki Sasaki  2023.
-      <a class="hover-white white-70" href="">CC BY-SA 4.0</a> unless otherwise noted.
+      <a class="hover-white white-70" href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> unless otherwise noted.
       <a class="hover-white white-70" href="/about">More about license...</a>
     </div>
     <div>

--- a/public/series/index.html
+++ b/public/series/index.html
@@ -199,7 +199,7 @@ Linux は、人工知能・機械学習分野でよく使われるOSです。 �
   <div class="flex justify-between w-100 mw9">
     <div class="f5 fw4 pv2 ph3 white-70">
       &copy;  Yuki Sasaki  2023.
-      <a class="hover-white white-70" href="">CC BY-SA 4.0</a> unless otherwise noted.
+      <a class="hover-white white-70" href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> unless otherwise noted.
       <a class="hover-white white-70" href="/about">More about license...</a>
     </div>
     <div>

--- a/public/series/機械学習エンジニアのためのlinux/index.html
+++ b/public/series/機械学習エンジニアのためのlinux/index.html
@@ -416,7 +416,7 @@ Linux を使ってテキスト・画像・映像・音声などの<strong>大量
   <div class="flex justify-between w-100 mw9">
     <div class="f5 fw4 pv2 ph3 white-70">
       &copy;  Yuki Sasaki  2023.
-      <a class="hover-white white-70" href="">CC BY-SA 4.0</a> unless otherwise noted.
+      <a class="hover-white white-70" href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> unless otherwise noted.
       <a class="hover-white white-70" href="/about">More about license...</a>
     </div>
     <div>


### PR DESCRIPTION
Resolves #4.

## Changes

Fixed two hyperlink elements pointing to the Creative Commons website:

* one in the footer (696873cae9a15383c6f89c74c58cd17f8de9edeb)
* the other in the "About yumem.io" page (9489318f2825893333319f65d4ec7cdc6ae480da), which previously directed to the CC0 license.